### PR TITLE
Added GameSettings to Snake

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,6 +136,7 @@ func (c *Connection) routeMessage(msg Message) {
 	case PLAYER_REGISTERED:
 		var m PlayerRegistered
 		c.messageToJson(&m, msg.bytes)
+		c.snake.OnPlayerRegistered(m.GameSettings)
 		c.conn.WriteJSON(StartGameMessage())
 
 		c.isTraining = m.GameMode == "TRAINING"

--- a/snake.go
+++ b/snake.go
@@ -5,11 +5,17 @@ import (
 )
 
 type Snake struct {
-	Name string
+	Name         string
+	GameSettings GameSettings
 }
 
 func (snake Snake) GetNextMove(m Map) string {
 	return "DOWN"
+}
+
+func (snake Snake) OnPlayerRegistered(s GameSettings) {
+	snake.GameSettings = s
+	log.Debug("Player registered.")
 }
 
 func (snake Snake) OnSnakeDead(reason string) {


### PR DESCRIPTION
Previously, the player's snake was unaware of the current game's settings (No. of players, Tail eating enabled etc.) which made it difficult to make certain moves. Now, the connection automatically provides said settings once the player has been successfully registered.